### PR TITLE
Time 128x128x80 case, bump compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,6 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 julia = "v1.7"
-ImageGeoms = "0.9"
+ImageGeoms = "0.9, 0.10"
 LimitedLDLFactorizations = "0.5"
 StatsBase = "0.33"

--- a/docs/lit/examples/02-b0map.jl
+++ b/docs/lit/examples/02-b0map.jl
@@ -74,6 +74,13 @@ if !@isdefined(ftrue)
     ftrue = (data["in_obj"]["ztrue"][:,:,zp] .* mask) / 2π / 1s # Hz
     ftrue .*= mask # true field map (in Hz) for simulation
     mag = data["in_obj"]["xtrue"] .* mask # true baseline magnitude
+    if false # 2× in all 3 dimensions to make (128,128,80) for timing test (≈6sec)
+        catd = (x,d) -> cat(x, x, dims=d)
+        bigify = (x) -> catd(catd(catd(x, 1), 2), 3)
+        ftrue = bigify(ftrue)
+        mag = bigify(mag)
+        mask = bigify(mask)
+    end
     (nx,ny,nz) = size(mag)
     clim = (-100,100) # display range in Hz
     jim(ftrue .* mask; clim, title="True fieldmap in Hz (Fig 3d)")


### PR DESCRIPTION
Add code to test 128x128x80 case, which is roughly 2mm isotropic.
It took about 6s on a 2020 iMac with 10 core i9 3.6 GHz and 64 GB memory.
Leaving it commented out to save CO2 in the cloud.