### PR TITLE
Test 2D finite differences for `order=2`; Test only `1` and `nightly`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.7', '1', 'nightly']
+        version: ['1', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v3

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-julia = "v1.7"
+julia = "v1.8"
 ImageGeoms = "0.9, 0.10"
 LimitedLDLFactorizations = "0.5"
 StatsBase = "0.33"

--- a/docs/lit/examples/01-overview.jl
+++ b/docs/lit/examples/01-overview.jl
@@ -110,14 +110,14 @@ dims = (40,30)
 x = LinRange(-1, 1, dims[1])
 y = LinRange(-1, 1, dims[2])
 phantom = @. abs(x) + abs(y') < 0.5
-sp = spdiff(dims; order=1)
-d1 = reshape(sp[1] * vec(phantom), dims)
-d2 = reshape(sp[2] * vec(phantom), dims)
-jim(
- jim(x, y, phantom, "Test image"),
- jim(x, y, d1, "1st dim differences"),
- jim(x, y, d2, "2nd dim differences"),
-)
+pl = Array{Any}(undef, 2, 2)
+for order in 1:2, d in 1:2
+    sp = spdiff(dims; order)
+    dif = reshape(sp[d] * vec(phantom), dims)
+    pl[d,order] = jim(x, y, dif, "dim$d differences\norder=$order")
+end
+pp = jim(x, y, phantom, "Test image")
+jim([[pp pp]; pl]...)
 
 
 #=

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ within each iteration.
 
 ### Compatibility
 
-Tested with Julia ≥ 1.7.
+Tested with Julia ≥ 1.8.
 
 
 ### Related packages

--- a/test/spdiff2.jl
+++ b/test/spdiff2.jl
@@ -16,4 +16,7 @@ using Test: @test, @testset, @test_throws, @inferred
     @test spdiff((4,5,6); order=2)[1] == kron(I(6*5), spdiff2(4))
     @test spdiff((4,5,6); order=2)[2] == kron(I(6), spdiff2(5), I(4))
     @test spdiff((4,5,6); order=2)[3] == kron(spdiff2(6), I(4*5))
+
+    @test spdiff((4,5); order=2)[1] == kron(I(5), spdiff2(4))
+    @test spdiff((4,5); order=2)[2] == kron(spdiff2(5), I(4))
 end


### PR DESCRIPTION
And illustrate them in the docs.  It looks OK.
Streamline tests to reduce carbon footprint.